### PR TITLE
Add new apigateway endpoint for accessing lambda function

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -47,6 +47,7 @@ provider:
     RawScadaIngestStackName: "tasq-raw-scada-ingest-enerplus-${{self:provider.stage}}"
     CleanScadaIngestStackName: "tasq-clean-scada-ingest-enerplus-${{self:provider.stage}}"
     ProceduresStackName: "tasq-procedures-${{self:provider.stage}}"
+    OperatorsAlertStackName: "tasq-workflow-${{self:provider.stage}}"
     StackMainUserId: "711589413744"
     EcrAddress: "711589413744.dkr.ecr.us-east-2.amazonaws.com"
     InboundStackName: "tasq-feature-extract-${{self:provider.stage}}"
@@ -97,6 +98,7 @@ resources:
   - ${{file(./src/resources/api_gateway/push_notification_resource.yml)}}
   - ${{file(./src/resources/api_gateway/client_data_ingest_resource.yml)}}
   - ${{file(./src/resources/api_gateway/procedures_resource.yml)}}
+  - ${{file(./src/resources/api_gateway/operators_resource.yml)}}
   - ${{file(./src/resources/dynamodb/dynamodb.yml)}}
   - ${{file(./src/resources/appsync/appsync.yml)}}
   

--- a/src/resources/api_gateway/operators_resource.yml
+++ b/src/resources/api_gateway/operators_resource.yml
@@ -1,0 +1,69 @@
+Resources:
+
+        ############# RESOURCE - operators ############
+
+  OperatorsAlertResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId:
+        Ref: RestApi
+      ParentId:
+        Fn::GetAtt:
+        - RestApi
+        - RootResourceId
+      PathPart: operators
+
+
+  OperatorsAlertLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName: !ImportValue "${{self:provider.environment.OperatorsAlertStackName}}:PostOperatorAlertSyncSource"
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+        - ''
+        - - 'arn:aws:execute-api:'
+          - Ref: AWS::Region
+          - ":"
+          - Ref: AWS::AccountId
+          - ":"
+          - Ref: RestApi
+          - "/*"
+
+  PostOperatorAlert:
+    Type: AWS::ApiGateway::Method
+    DependsOn: OperatorsAlertLambdaPermission
+    Properties:
+      AuthorizationType: CUSTOM
+      AuthorizerId:
+        Ref: RestApiAuthorizer
+      RestApiId:
+        Ref: RestApi
+      ResourceId:
+        Ref: OperatorsAlertResource
+      HttpMethod: POST
+      Integration:
+        Type: AWS
+        IntegrationHttpMethod: POST
+        Uri:
+          Fn::Join:
+          - ''
+          - - 'arn:aws:apigateway:'
+            - Ref: AWS::Region
+            - ":lambda:path/2015-03-31/functions/"
+            - !ImportValue "${{self:provider.environment.OperatorsAlertStackName}}:PostOperatorAlertSyncSource"
+            - "/invocations"
+        IntegrationResponses:
+        - StatusCode: 200
+        RequestTemplates:
+          "application/json": "{\"visibility\": \"$input.params('visibility')\",\"msg\": \"$input.params('msg')\",\"operator\": \"$input.params('operator')\"}"
+      RequestModels:
+        application/json:
+          Ref: Model
+      RequestParameters:
+        method.request.header.Authorization: true
+      MethodResponses:
+      - ResponseModels:
+          application/json: Empty
+        StatusCode: 200

--- a/src/resources/api_gateway/operators_resource.yml
+++ b/src/resources/api_gateway/operators_resource.yml
@@ -14,7 +14,7 @@ Resources:
       PathPart: operators
 
 
-  OperatorsAlertLambdaPermission:
+  PostOperatorAlertLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:invokeFunction
@@ -33,7 +33,7 @@ Resources:
 
   PostOperatorAlert:
     Type: AWS::ApiGateway::Method
-    DependsOn: OperatorsAlertLambdaPermission
+    DependsOn: PostOperatorAlertLambdaPermission
     Properties:
       AuthorizationType: CUSTOM
       AuthorizerId:


### PR DESCRIPTION
## Problem
We need a new apigateway endpoint to access lambda function for creating operator alerts. Currently operators can be created through Graphql using AppSync resource but we cannot use permanent token with it. 

## Solution
New apigateway endpoint added along with permission to Lambda function.